### PR TITLE
[22115] Apply new icon styling (Announcements)

### DIFF
--- a/app/views/announcements/edit.html.erb
+++ b/app/views/announcements/edit.html.erb
@@ -18,5 +18,5 @@
     <%= f.check_box :active, label: l('announcements.active') %>
   </div>
   <hr class="form-separator">
-  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with opf/openproject#3873 since there the icon font is updated.

https://community.openproject.org/work_packages/22115/activity
